### PR TITLE
add some tests for capnp.Pointer

### DIFF
--- a/packages/capnp-ts/src/serialization/pointers/pointer.ts
+++ b/packages/capnp-ts/src/serialization/pointers/pointer.ts
@@ -841,6 +841,7 @@ export class Pointer {
   /**
    * Read some bits off a list pointer to make sure it has the right pointer data.
    *
+   * @internal
    * @param {PointerType} pointerType The expected pointer type.
    * @param {ListElementSize} [elementSize] For list pointers, the expected element size. Leave this
    * undefined for struct pointers.

--- a/packages/capnp-ts/src/serialization/pointers/pointer.ts
+++ b/packages/capnp-ts/src/serialization/pointers/pointer.ts
@@ -1036,7 +1036,7 @@ export class Pointer {
 
       const byteLength = padToWord(srcElementSize === ListElementSize.BIT
         ? srcLength + 7 >>> 3
-        : Pointer._getListElementByteLength(srcElementSize));
+        : Pointer._getListElementByteLength(srcElementSize) * srcLength);
       const wordLength = byteLength >>> 3;
 
       dstContent = dst.segment.allocate(byteLength);

--- a/packages/capnp-ts/src/serialization/pointers/pointer.ts
+++ b/packages/capnp-ts/src/serialization/pointers/pointer.ts
@@ -1003,8 +1003,6 @@ export class Pointer {
 
       dstContent.segment.copyWord(dstContent.byteOffset, srcContent.segment, srcContent.byteOffset - 8);
 
-      dstContent.byteOffset += 8;
-
       // Copy the entire contents, including all pointers. This should be more efficient than making `srcLength`
       // copies to skip the pointer sections, and we're about to rewrite all those pointers anyway.
 
@@ -1013,7 +1011,7 @@ export class Pointer {
 
         const wordLength = srcCompositeSize.getWordLength() * srcLength;
 
-        dstContent.segment.copyWords(dstContent.byteOffset, srcContent.segment, srcContent.byteOffset, wordLength);
+        dstContent.segment.copyWords(dstContent.byteOffset + 8, srcContent.segment, srcContent.byteOffset, wordLength);
 
       }
 
@@ -1026,7 +1024,7 @@ export class Pointer {
           const offset = i * srcStructByteLength + srcCompositeSize.dataByteLength + (j << 3);
 
           const srcPtr = new Pointer(srcContent.segment, srcContent.byteOffset + offset, src._depthLimit - 1);
-          const dstPtr = new Pointer(dstContent.segment, dstContent.byteOffset + offset, dst._depthLimit - 1);
+          const dstPtr = new Pointer(dstContent.segment, dstContent.byteOffset + offset + 8, dst._depthLimit - 1);
 
           dstPtr._copyFrom(srcPtr);
 

--- a/packages/capnp-ts/src/serialization/segment.ts
+++ b/packages/capnp-ts/src/serialization/segment.ts
@@ -110,8 +110,8 @@ export class Segment implements DataView {
 
   copyWords(byteOffset: number, srcSegment: Segment, srcByteOffset: number, wordLength: number): void {
 
-    const src = new Float64Array(this.buffer, byteOffset, wordLength);
-    const dst = new Float64Array(srcSegment.buffer, srcByteOffset, wordLength);
+    const dst = new Float64Array(this.buffer, byteOffset, wordLength);
+    const src = new Float64Array(srcSegment.buffer, srcByteOffset, wordLength);
 
     dst.set(src);
 

--- a/packages/capnp-ts/src/util.ts
+++ b/packages/capnp-ts/src/util.ts
@@ -160,7 +160,7 @@ export function dumpBuffer(buffer: ArrayBuffer | ArrayBufferView): string {
     let s = '';
     let k;
 
-    for (k = 0; k < 16; k++) {
+    for (k = 0; k < 16 && j + k < b.byteLength; k++) {
 
       const v = b[j + k];
 

--- a/packages/capnp-ts/test/integration/serialization-demo.spec.ts
+++ b/packages/capnp-ts/test/integration/serialization-demo.spec.ts
@@ -129,3 +129,33 @@ tap.test('read address book', (t) => {
   t.end();
 
 });
+
+tap.test('copy pointers from other message', (t) => {
+
+  const message1 = new capnp.Message();
+  const addressBook1 = message1.initRoot(AddressBook);
+  const people1 = addressBook1.initPeople(2);
+  const alice1 = people1.get(1);
+
+  alice1.setName('Alice');
+  alice1.setEmail('alice@example.com');
+  alice1.setId(456);
+
+  const message2 = new capnp.Message();
+  const addressBook2 = message2.initRoot(AddressBook);
+
+  addressBook2.setPeople(people1);
+
+  const people2 = addressBook2.getPeople();
+  const alice2 = people2.get(1);
+
+  t.equal(people2.getLength(), 2);
+  t.equal(alice2.getName(), 'Alice');
+  t.equal(alice2.getEmail(), 'alice@example.com');
+  t.equal(alice2.getId(), 456);
+
+  console.log(message2.dump());
+
+  t.end();
+
+});

--- a/packages/capnp-ts/test/unit/serialization/pointers/pointer.spec.ts
+++ b/packages/capnp-ts/test/unit/serialization/pointers/pointer.spec.ts
@@ -1,0 +1,102 @@
+import {Message, Pointer} from '../../../../lib';
+import * as C from '../../../../lib/constants';
+import {tap} from '../../../util';
+
+/* tslint:disable no-any */
+
+tap.test('new Pointer()', (t) => {
+
+  const m = new Message();
+  const s = m.getSegment(0);
+
+  const initialTraversalLimit = (m as any)._traversalLimit as number;
+
+  t.throws(() => {
+
+    /* tslint:disable-next-line */
+    new Pointer(s, 0, 0);
+
+  }, undefined, 'should throw when exceeding the depth limit');
+
+  const p = new Pointer(s, 4);
+
+  t.equal((m as any)._traversalLimit, initialTraversalLimit - 8, 'should track pointer allocation in the message');
+
+  t.throws(() => {
+
+    /* tslint:disable-next-line */
+    new Pointer(s, -1);
+
+  }, undefined, 'should throw with a negative offset');
+
+  t.throws(() => {
+
+    /* tslint:disable-next-line */
+    new Pointer(s, 100);
+
+  }, undefined, 'should throw when exceeding segment bounds');
+
+  t.equal(s.byteLength, 8);
+  t.ok(new Pointer(s, 8), 'should allow creating pointers at the end of the segment');
+
+  t.equal(p.segment, s);
+  t.equal(p.byteOffset, 4);
+  t.equal((p as any)._depthLimit, C.MAX_DEPTH);
+
+  t.end();
+
+});
+
+tap.test('Pointer.adopt(), Pointer.disown()', (t) => {
+
+  const m = new Message();
+  const s = m.getSegment(0);
+  const p = new Pointer(s, 0);
+
+  // Empty bit list.
+  s.setUint32(0, 0x00000001);
+  s.setUint32(4, 0x00000001);
+
+  const o = p.disown();
+
+  t.equal(s.getUint32(0), 0x00000000);
+  t.equal(s.getUint32(4), 0x00000000);
+
+  p.adopt(o);
+
+  t.equal(s.getUint32(0), 0x00000001);
+  t.equal(s.getUint32(4), 0x00000001);
+
+  t.end();
+
+});
+
+tap.test('Pointer.dump()', (t) => {
+
+  const m = new Message();
+  const s = m.getSegment(0);
+  const p = new Pointer(s, 0);
+
+  s.setUint32(0, 0x00000001);
+  s.setUint32(4, 0x00000002);
+
+  t.equal(p.dump(), '[01 00 00 00 02 00 00 00]');
+
+  t.end();
+
+});
+
+tap.test('Pointer.toString()', (t) => {
+
+  const m = new Message();
+  const s = m.getSegment(0);
+  const p = new Pointer(s, 0);
+
+  s.setUint32(0, 0x00000001);
+  s.setUint32(4, 0x00000002);
+
+  t.equal(p.toString(), 'Pointer_0@0x00000000,[01 00 00 00 02 00 00 00],limit:0x7fffffff');
+
+  t.end();
+
+});


### PR DESCRIPTION
This is a far cry from 100%, but the public methods are tested and it's already managed to uncover some super broken behavior for pointer copy operations (:face_with_head_bandage: :palm_tree:).

100% coverage will wait until #47 is addressed to make testing the private/internal methods much easier.