### PR TITLE
Correct typescript compiler errors.

### DIFF
--- a/packages/capnp-ts/src/serialization/message.ts
+++ b/packages/capnp-ts/src/serialization/message.ts
@@ -160,7 +160,7 @@ export function initMessage(
 
   let buf: ArrayBuffer = src as ArrayBuffer;
 
-  if (isArrayBufferView(buf)) buf = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  if (isArrayBufferView(buf)) buf = (buf.buffer as ArrayBuffer).slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
 
   if (packed) buf = unpack(buf);
 
@@ -428,7 +428,7 @@ export function toArrayBuffer(m: Message): ArrayBuffer {
 
   });
 
-  return out.buffer;
+  return out.buffer as ArrayBuffer;
 
 }
 
@@ -459,7 +459,7 @@ export function toPackedArrayBuffer(m: Message): ArrayBuffer {
 
   });
 
-  return out.buffer;
+  return out.buffer as ArrayBuffer;
 
 }
 
@@ -471,7 +471,7 @@ export function getStreamFrame(m: Message): ArrayBuffer {
 
     // Don't bother allocating the first segment, just return a single zero word for the frame header.
 
-    return new Float64Array(1).buffer;
+    return new Float64Array(1).buffer as ArrayBuffer;
 
   }
 

--- a/packages/capnp-ts/src/serialization/packing.ts
+++ b/packages/capnp-ts/src/serialization/packing.ts
@@ -342,7 +342,7 @@ export function pack(unpacked: ArrayBuffer, byteOffset = 0, byteLength?: number)
 
   }
 
-  return new Uint8Array(dst).buffer;
+  return new Uint8Array(dst).buffer as ArrayBuffer;
 
 }
 
@@ -417,6 +417,6 @@ export function unpack(packed: ArrayBuffer): ArrayBuffer {
 
   }
 
-  return dst.buffer;
+  return dst.buffer as ArrayBuffer;
 
 }


### PR DESCRIPTION
I encountered these with tsc Version 2.9.2 while directly including capnp-ts/src. 