### PR TITLE
Fix parse crash on null pointer dereference in resize

### DIFF
--- a/packages/capnp-ts/src/serialization/pointers/struct.ts
+++ b/packages/capnp-ts/src/serialization/pointers/struct.ts
@@ -238,6 +238,10 @@ export function resize(dstSize: ObjectSize, s: Struct): void {
       srcContent.segment,
       srcContent.byteOffset + srcSize.dataByteLength + i * 8
     );
+    if (isNull(srcPtr)) {
+      // If source pointer is null, leave the destination pointer as default null.
+      continue
+    }
     const srcPtrTarget = followFars(srcPtr);
     const srcPtrContent = getContent(srcPtr);
     const dstPtr = new Pointer(


### PR DESCRIPTION
Fixes issue similar to #78 (perhaps same) where a sender doesn't set a text field in the source proto can cause a unexpected validation error on the receiver when parsing the proto message.
What appears to happen is a null source pointer is dereferenced and the data is assigned to the destination pointer in the resize function.
We are able to repro this consistently when parsing large nested proto messages when presumably the dereferenced data in the source segment happens to contain nonzero data.