### PR TITLE
fix imports with nested enums

### DIFF
--- a/packages/capnp-ts/test/integration/test-import.capnp.ts
+++ b/packages/capnp-ts/test/integration/test-import.capnp.ts
@@ -6,7 +6,7 @@
 
 import * as capnp from "capnp-ts";
 import { ObjectSize as __O, Struct as __S } from 'capnp-ts';
-import { TestAllTypes } from "./test.capnp";
+import { TestEnum, TestAllTypes } from "./test.capnp";
 export const _capnpFileId = "f36d7b330303c66e";
 export class TestImport extends __S {
     static readonly _capnp = { displayName: "TestImport", id: "bc55b08b672b5d97", size: new __O(0, 1) };

--- a/packages/capnp-ts/test/integration/test-import2.capnp.ts
+++ b/packages/capnp-ts/test/integration/test-import2.capnp.ts
@@ -6,9 +6,9 @@
 
 import * as capnp from "capnp-ts";
 import { ObjectSize as __O, Struct as __S } from 'capnp-ts';
-import { Node, Field, Enumerant, Superclass, Method, Type, Brand, Value, Annotation } from "capnp-ts/lib/std/schema.capnp";
+import { Node, Node_Parameter, Node_NestedNode, Field, Enumerant, Superclass, Method, Type, Brand, Brand_Scope, Brand_Binding, Value, Annotation, ElementSize } from "capnp-ts/lib/std/schema.capnp";
 import { TestImport } from "./test-import.capnp";
-import { TestAllTypes } from "./test.capnp";
+import { TestEnum, TestAllTypes } from "./test.capnp";
 export const _capnpFileId = "c64a3bf0338a124a";
 export class TestImport2 extends __S {
     static readonly _capnp = { displayName: "TestImport2", id: "f6bd77f100ecb0ff", size: new __O(0, 3) };


### PR DESCRIPTION
schema definitions that reference enums in structs in imports fail with errors like this:
```
log.capnp.ts:833:23 Cannot find name 'CarParams_SafetyModel'.
log.capnp.ts:834:27 Cannot find name 'CarParams_SafetyModel'.
log.capnp.ts:898:53 Cannot find name 'RadarData_Error'.
log.capnp.ts:899:50 Cannot find name 'RadarData_Error'.
log.capnp.ts:900:34 Cannot find name 'RadarData_Error'.
log.capnp.ts:902:49 Cannot find name 'RadarData_Error'.
log.capnp.ts:903:38 Cannot find name 'RadarData_Error'.
log.capnp.ts:1226:22 Cannot find name 'CarControl_HUDControl_AudibleAlert'.
log.capnp.ts:1227:26 Cannot find name 'CarControl_HUDControl_AudibleAlert'.
log.capnp.ts:833:23 Cannot find name 'CarParams_SafetyModel'.
log.capnp.ts:834:27 Cannot find name 'CarParams_SafetyModel'.
log.capnp.ts:898:53 Cannot find name 'RadarData_Error'.
log.capnp.ts:899:50 Cannot find name 'RadarData_Error'.
log.capnp.ts:900:34 Cannot find name 'RadarData_Error'.
log.capnp.ts:902:49 Cannot find name 'RadarData_Error'.
log.capnp.ts:903:38 Cannot find name 'RadarData_Error'.
log.capnp.ts:1226:22 Cannot find name 'CarControl_HUDControl_AudibleAlert'.
log.capnp.ts:1227:26 Cannot find name 'CarControl_HUDControl_AudibleAlert'.
Error: CAPNPC-TS009 Failed to transpile emitted schema source code; see above for error messages.
    at transpileAll (/home/batman/capnp-ts/packages/capnpc-js/lib/index.js:77:15)
    at /home/batman/capnp-ts/packages/capnpc-js/lib/index.js:39:21
    at tryCatcher (/home/batman/capnp-ts/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/batman/capnp-ts/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/home/batman/capnp-ts/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/home/batman/capnp-ts/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/home/batman/capnp-ts/node_modules/bluebird/js/release/promise.js:693:18)
    at Async._drainQueue (/home/batman/capnp-ts/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/home/batman/capnp-ts/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/home/batman/capnp-ts/node_modules/bluebird/js/release/async.js:17:14)
    at processImmediate (internal/timers.js:461:21)
./node_modules/.bin/capnpc-js: plugin failed: exit code 1
```

example schema definition with the issue (which generated the above output):
https://github.com/commaai/cereal/blob/122c3719108d640e5ae296959cdf32a1c2c49284/log.capnp#L358

this fix recursively adds structs and enums that are in imports