### PR TITLE
fix: remove redundant `_capnp` declaration in `Struct`

### DIFF
--- a/packages/capnp-ts/src/serialization/pointers/struct.ts
+++ b/packages/capnp-ts/src/serialization/pointers/struct.ts
@@ -106,8 +106,6 @@ export class Struct extends Pointer {
   static readonly setText = setText;
   static readonly testWhich = testWhich;
 
-  readonly _capnp!: _Struct;
-
   /**
    * Create a new pointer to a struct.
    *


### PR DESCRIPTION
Hey! 👋 Thanks for building this package! Super useful! 🙂 I hit this error when trying to type check a project:
```
node_modules/capnp-ts/src/serialization/pointers/struct.ts:110:12 - error TS2612: Property '_capnp' will overwrite the base property in 'Pointer'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

110   readonly _capnp!: _Struct;
               ~~~~~~


Found 1 error in node_modules/capnp-ts/src/serialization/pointers/struct.ts:110
```
Removing the redundant declaration seems to fix this. 👍 