### PR TITLE
fix: increase traverse limit for large capnp files

### DIFF
--- a/packages/capnp-ts/src/constants.ts
+++ b/packages/capnp-ts/src/constants.ts
@@ -29,7 +29,7 @@ export const DEFAULT_DEPTH_LIMIT = 64;
  * message's traversal limit gets decremented each time.
  */
 
-export const DEFAULT_TRAVERSE_LIMIT = 64 << 20; // 64 MiB
+export const DEFAULT_TRAVERSE_LIMIT = 128 << 20; // 128 MiB
 
 /**
  * When allocating array buffers dynamically (while packing or in certain Arena implementations) the previous buffer's


### PR DESCRIPTION
Hi. We are using `capnpc` compiler to compile Cap'n Proto file to TypeScript and JavaScript languages. Our file contains a lot of messages from Bluetooth Mesh protocol. With the latest version, we are hitting traverse limit. This PR aims to increase this limit.

Current version of the file can be downloaded from: https://api.platform-prod.silvair.com/public/docs/#/, under `/public​/control​/message_definitions`