### PR TITLE
feat: unpack messages segment-by-segment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ npm := npm
 # vars
 
 capnp_ts := packages/capnp-ts
+capnp_ts_test := packages/capnp-ts-test
 capnpc_ts := packages/capnpc-ts
 js_examples := packages/js_examples
 
@@ -54,7 +55,7 @@ export PATH := $(CURDIR)/$(capnpc_ts)/bin:$(PATH)
 .PHONY: benchmark
 benchmark: build
 benchmark:
-	$(node) $(capnp_ts)/benchmark/index.js
+	$(node) $(capnp_ts_test)/test/benchmark/index.js
 	@echo
 
 .PHONY: build-prelude

--- a/README.md
+++ b/README.md
@@ -19,14 +19,10 @@
 
 ```
 
-![test status](https://img.shields.io/github/workflow/status/jdiaz5513/capnp-ts/cd/master?style=flat-square)
 ![npm](https://img.shields.io/npm/v/capnp-ts?color=green&style=flat-square)
-![vulnerabilities](https://img.shields.io/snyk/vulnerabilities/npm/capnp-ts?style=flat-square)
 ![issues](https://img.shields.io/github/issues/jdiaz5513/capnp-ts?style=flat-square)
 
 This is a TypeScript implementation of the [Cap'n Proto](https://capnproto.org) serialization protocol. Start with the [Cap'n Proto Introduction](https://capnproto.org/index.html) for more detailed information on what this is about.
-
-> WARNING: THIS IS ALPHA QUALITY SOFTWARE. USE AT YOUR OWN RISK. AUTHORS ARE NOT RESPONSIBLE FOR LOSS OF LIMB, LIFE, SANITY, OR RETIREMENT FUNDS DUE TO USE OF THIS SOFTWARE.
 
 - [Packages](#packages)
 - [Project Status](#project-status)
@@ -49,22 +45,18 @@ This repository is managed as a monorepo composed of separate packages.
 
 | Package                            | Version                                                                      | Dependencies                                                                                                      |
 | :--------------------------------- | :--------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------- |
-| [`capnp-ts`](/packages/capnp-ts)   | ![npm](https://img.shields.io/npm/v/capnp-ts?color=green&style=flat-square)  | ![dependency status](https://img.shields.io/david/jdiaz5513/capnp-ts?path=packages%2Fcapnp-ts&style=flat-square)  |
-| [`capnpc-ts`](/packages/capnpc-ts) | ![npm](https://img.shields.io/npm/v/capnpc-ts?color=green&style=flat-square) | ![dependency status](https://img.shields.io/david/jdiaz5513/capnp-ts?path=packages%2Fcapnpc-ts&style=flat-square) |
-| [`capnpc-js`](/packages/capnpc-js) | ![npm](https://img.shields.io/npm/v/capnpc-js?color=green&style=flat-square) | ![dependency status](https://img.shields.io/david/jdiaz5513/capnp-ts?path=packages%2Fcapnpc-js&style=flat-square) |
+| [`capnp-ts`](/packages/capnp-ts)   | ![npm](https://img.shields.io/npm/v/capnp-ts) | ![dependency status](https://img.shields.io/librariesio/release/npm/capnp-ts) |
+| [`capnpc-ts`](/packages/capnpc-ts) | ![npm](https://img.shields.io/npm/v/capnpc-ts) | ![dependency status](https://img.shields.io/librariesio/release/npm/capnpc-ts) |
 
 - `capnp-ts` is the core Cap'n Proto library for Typescript. It is a required import for all compiled schema files, and the starting point for reading/writing a Cap'n Proto message.
 - `capnpc-ts` is the schema compiler plugin for TypeScript. It is intended to be invoked by the [`capnp`](https://capnproto.org/capnp-tool.html) tool.
-- `capnpc-js` is the schema compiler plugin for JavaScript. It is intended to be invoked by the [`capnp`](https://capnproto.org/capnp-tool.html) tool.
 
 ## Project Status
 
-This project is under active **alpha** stage development.
+This project is under active **beta** stage development.
 
-> Until version `1.x.x` lands expect that the top level API **will** change.
-
-- Serialization: **working, may be missing features**
-- Schema Compiler: **working, may be missing features**
+- Serialization: **reference quality with tests for byte-identical output**
+- Schema Compiler: **all serialization features fully supported**
 - [RPC Level 1](https://capnproto.org/rpc.html#protocol-features): **not implemented**
 - [RPC Level 2](https://capnproto.org/rpc.html#protocol-features): **not implemented**
 - [RPC Level 3](https://capnproto.org/rpc.html#protocol-features): **not implemented**
@@ -82,8 +74,6 @@ You will need the schema compiler as well (global installation recommended):
 
 ```shell
 npm install -g capnpc-ts # For TypeScript
-# OR
-npm install -g capnpc-js # For JavaScript
 ```
 
 The schema compiler is a [Cap'n Proto plugin](https://capnproto.org/otherlang.html#how-to-write-compiler-plugins) and requires the `capnpc` binary in order to do anything useful; follow the [Cap'n Proto installation instructions](https://capnproto.org/install.html) to install it on your system.
@@ -106,13 +96,7 @@ Run the following to compile a schema file into TypeScript source code:
 capnpc -o ts path/to/myschema.capnp
 ```
 
-Or for JavaScript:
-
-```shell
-capnpc -o js path/to/myschema.capnp
-```
-
-Running that command will create a file named `path/to/myschema.capnp.ts` (or `.js`).
+Running that command will create a file named `path/to/myschema.capnp.ts`.
 
 > These instructions assume `capnpc-ts` was installed globally and is available from `$PATH`. If not, change the `-o` option to something like `-o node_modules/.bin/capnpc-ts` or `-o capnp-ts/packages/capnpc-ts/bin/capnpc-ts.js` so it points to your local `capnpc-ts` install.
 
@@ -149,7 +133,7 @@ Also, the name `capnp-js` is already reserved on npm from a [previous attempt by
 ```javascript
 const capnp = require("capnp-ts");
 
-const MyStruct = require("./myschema.capnp").MyStruct;
+const MyStruct = require("./myschema.capnp.js").MyStruct;
 
 function loadMessage(buffer) {
   const message = new capnp.Message(buffer);
@@ -166,9 +150,9 @@ Using a tool like [webpack](https://webpack.js.org/) one should be able to bundl
 
 A deliberate effort was made to avoid using nodejs specific features (at the expense of performance) to maintain compatibility with browser environments.
 
-**Note that this library has not yet been tested in a web browser.**
+**Note that this library does not yet run test cases for web browsers, though it is technically supported as a runtime target.**
 
-> In the future a special nodejs version of the library may be released to take advantage of `Buffer` which gives access to unsafe malloc style allocation (as opposed to calloc style allocation in `ArrayBuffer` which always zeroes out the memory).
+> In the future a special nodejs-only version of the library may be released to take advantage of `Buffer` which gives access to unsafe malloc style allocation (as opposed to calloc style allocation in `ArrayBuffer` which always zeroes out the memory).
 
 ## Building
 
@@ -176,7 +160,11 @@ Before building the source you will need a few prerequisites which can be manage
 
 ### Initial Setup
 
-Run `direnv allow` to set up system dependencies and the **node_modules** directories for the monorepo and each package.
+Run `direnv allow` to set up system dependencies and the **node_modules** directories for the monorepo and each package. Or, with just nix installed:
+
+```shell
+nix develop .
+```
 
 ### Build Targets
 
@@ -192,7 +180,7 @@ make
 
 #### `benchmark`
 
-Runs all available benchmarks in `packages/capnp-ts/test/benchmark`.
+Runs all available benchmarks in `packages/capnp-ts-test/test/benchmark`.
 
 #### `build`
 
@@ -206,13 +194,9 @@ Generates a coverage report.
 
 Runs `eslint` and prints out any linter violations.
 
-#### `publish`
-
-Publish the latest release to NPM. Intended to only be run from CI.
-
 #### `release`
 
-Create a new release using [standard-version](https://github.com/conventional-changelog/standard-version); use this to trigger a continuous deployment run after pushing the new tag.
+Create a new release; use this to trigger a continuous deployment run after pushing the new tag.
 
 #### `test`
 
@@ -220,17 +204,13 @@ Runs the test suite and prints out a human-readable test result.
 
 #### `watch`
 
-Runs the test suite in a loop, recompiling any changes to the source as it is saved to disk.
+Runs the tap REPL which allows running the tests in watch mode as well as other features.
 
 ## Testing
 
-Tests are written using [node-tap](http://www.node-tap.org/) and are located in the `test/` subdirectory for each package. The goal for this repository is to reach 100% coverage on critical code. Exceptions may be made (e.g. for benchmark code) using special istanbul comments:
+Tests are written using [node-tap](http://www.node-tap.org/) and are located in the `test/` subdirectory for each package. The goal for this repository is to reach 100% coverage on critical code.
 
-```javascript
-/* istanbul ignore next */ // ignore the next statement/block
-/* istanbul ignore if */ // ignore an if branch
-/* istanbul ignore else */ // ignore an else branch
-```
+The `packages/capnp-ts-test/test/parity/` integration suite additionally verifies byte-exact compatibility against the C++ reference implementation by invoking the `capnp` binary. All test suites run hermetically under `nix flake check` (as well as basic flake-level checks).
 
 ## Debugging
 

--- a/packages/capnp-ts-test/test/benchmark/index.ts
+++ b/packages/capnp-ts-test/test/benchmark/index.ts
@@ -1,1 +1,2 @@
 import "./serialization-demo.bench";
+import "./large.bench";

--- a/packages/capnp-ts-test/test/benchmark/large.bench.ts
+++ b/packages/capnp-ts-test/test/benchmark/large.bench.ts
@@ -1,0 +1,110 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import { Suite } from "benchmark";
+
+import * as capnp from "capnp-ts";
+import { AddressBook } from "../integration/serialization-demo";
+import { logBench } from "../util";
+
+const N_PEOPLE = 1000;
+const N_PHONES = 3;
+
+// Build a capnp message with N_PEOPLE people, each with N_PHONES phones.
+const buildMsg = new capnp.Message();
+const book = buildMsg.initRoot(AddressBook);
+const people = book.initPeople(N_PEOPLE);
+for (let i = 0; i < N_PEOPLE; i++) {
+  const p = people.get(i);
+  p.setId(i);
+  p.setName(`Person ${i}`);
+  p.setEmail(`person${i}@example.com`);
+  const phones = p.initPhones(N_PHONES);
+  for (let j = 0; j < N_PHONES; j++) {
+    phones.get(j).setNumber(`555-010${j}`);
+  }
+}
+
+const seg = buildMsg.getSegment(0);
+const capnpBuf = seg.buffer.slice(0, seg.byteLength);
+
+// Build equivalent JSON.
+const jsonStr = JSON.stringify({
+  people: Array.from({ length: N_PEOPLE }, (_, i) => ({
+    id: i,
+    name: `Person ${i}`,
+    email: `person${i}@example.com`,
+    phones: Array.from({ length: N_PHONES }, (_, j) => ({
+      number: `555-010${j}`,
+    })),
+  })),
+});
+
+// eslint-disable-next-line no-console
+console.log(`\nDataset: ${N_PEOPLE} people x ${N_PHONES} phones each`);
+// eslint-disable-next-line no-console
+console.log(`  capnp: ${capnpBuf.byteLength} bytes, JSON: ${Buffer.byteLength(jsonStr)} bytes`);
+
+// --- Benchmark 1: Parse only (no field access) ---
+
+const parseOnly = new Suite(`parse only (${N_PEOPLE} people)`)
+  .add("JSON.parse", () => {
+    JSON.parse(jsonStr);
+  })
+  .add("capnp.Message (lazy)", () => {
+    new capnp.Message(capnpBuf, false, true);
+  });
+
+// --- Benchmark 2: Selective access (get one person's name from the middle) ---
+
+const selective = new Suite(`selective access (person #${N_PEOPLE >> 1} name only)`)
+  .add("JSON.parse + access", () => {
+    const ab = JSON.parse(jsonStr);
+    ab.people[N_PEOPLE >> 1].name;
+  })
+  .add("capnp.Message + access", () => {
+    const m = new capnp.Message(capnpBuf, false, true);
+    m.getRoot(AddressBook).getPeople().get(N_PEOPLE >> 1).getName();
+  });
+
+// --- Benchmark 3: List length only ---
+
+const lengthOnly = new Suite(`list length only (${N_PEOPLE} people)`)
+  .add("JSON.parse + .length", () => {
+    JSON.parse(jsonStr).people.length;
+  })
+  .add("capnp.Message + getLength()", () => {
+    new capnp.Message(capnpBuf, false, true).getRoot(AddressBook).getPeople().getLength();
+  });
+
+// --- Benchmark 4: Full traversal (every person, every phone) ---
+
+const fullTraversal = new Suite(`full traversal (${N_PEOPLE * N_PHONES} phone records)`)
+  .add("JSON.parse + traverse", () => {
+    const ab = JSON.parse(jsonStr);
+    for (const person of ab.people) {
+      for (const phone of person.phones) {
+        phone.number.toUpperCase();
+      }
+    }
+  })
+  .add("capnp.Message + traverse", () => {
+    const m = new capnp.Message(capnpBuf, false, true);
+    const ab = m.getRoot(AddressBook);
+    const ps = ab.getPeople();
+    const n = ps.getLength();
+    for (let i = 0; i < n; i++) {
+      const person = ps.get(i);
+      const phones = person.getPhones();
+      const m2 = phones.getLength();
+      for (let j = 0; j < m2; j++) {
+        phones.get(j).getNumber().toUpperCase();
+      }
+    }
+  });
+
+logBench(parseOnly).run();
+logBench(selective).run();
+logBench(lengthOnly).run();
+logBench(fullTraversal).run();

--- a/packages/capnp-ts-test/test/benchmark/large.bench.ts
+++ b/packages/capnp-ts-test/test/benchmark/large.bench.ts
@@ -5,6 +5,7 @@
 import { Suite } from "benchmark";
 
 import * as capnp from "capnp-ts";
+import { getUnpackedByteLength, PackedReader, unpack } from "capnp-ts/src/serialization/packing";
 import { AddressBook } from "../integration/serialization-demo";
 import { logBench } from "../util";
 
@@ -108,3 +109,24 @@ logBench(parseOnly).run();
 logBench(selective).run();
 logBench(lengthOnly).run();
 logBench(fullTraversal).run();
+
+// --- Benchmark 5: Packed read — 2-pass vs streaming 1-pass ---
+
+const packedSingle = new capnp.Message(capnpBuf, false, true).toPackedArrayBuffer();
+const packedArr = new Uint8Array(packedSingle);
+
+const packedRead = new Suite(`packed unpack (${N_PEOPLE} people)`)
+  .add("2-pass (getUnpackedByteLength + unpack)", () => {
+    const len = getUnpackedByteLength(packedSingle);
+    const dst = new Uint8Array(new ArrayBuffer(len));
+    unpack(packedArr, 0, dst);
+  })
+  .add("1-pass (PackedReader streaming)", () => {
+    const reader = new PackedReader(packedArr);
+    const hdr = new Uint8Array(8);
+    reader.read(hdr);
+    const seg0Words = new DataView(hdr.buffer).getUint32(4, true);
+    reader.read(new Uint8Array(new ArrayBuffer(seg0Words * 8)));
+  });
+
+logBench(packedRead).run();

--- a/packages/capnp-ts-test/test/benchmark/serialization-demo.bench.ts
+++ b/packages/capnp-ts-test/test/benchmark/serialization-demo.bench.ts
@@ -14,8 +14,7 @@ import { logBench, readFileBuffer } from "../util";
 const jsonBuffer = new Uint8Array(readFileBuffer("test/data/serialization-demo.json"));
 const jsonString = readFileSync(path.join(__dirname, "../../", "test/data/serialization-demo.json"), "utf-8");
 const messageData = readFileBuffer("test/data/serialization-demo.bin");
-// Let's preprocess it so we have just the raw segment data.
-const messageSegment = new capnp.Message(messageData).getSegment(0).buffer;
+const messageSegment = new capnp.Message(messageData, false).getSegment(0).buffer;
 
 const deeplyNested = new Suite("iteration over deeply nested lists")
 

--- a/packages/capnp-ts-test/test/parity/parity-test.capnp
+++ b/packages/capnp-ts-test/test/parity/parity-test.capnp
@@ -1,0 +1,55 @@
+@0xb1b1b1b1b1b1b1b1;
+
+# Subset of capnproto/capnproto's c++/src/capnp/test.capnp, trimmed to
+# features capnp-ts supports. Used by the parity harness to validate byte
+# compatibility against the C++ reference implementation.
+#
+# Run `capnp compile -ots` against this file to regenerate the .ts.
+
+enum TestEnum {
+  foo @0;
+  bar @1;
+  baz @2;
+  qux @3;
+  quux @4;
+  corge @5;
+  grault @6;
+  garply @7;
+}
+
+struct TestAllTypes {
+  voidField      @0  :Void;
+  boolField      @1  :Bool;
+  int8Field      @2  :Int8;
+  int16Field     @3  :Int16;
+  int32Field     @4  :Int32;
+  int64Field     @5  :Int64;
+  uInt8Field     @6  :UInt8;
+  uInt16Field    @7  :UInt16;
+  uInt32Field    @8  :UInt32;
+  uInt64Field    @9  :UInt64;
+  float32Field   @10 :Float32;
+  float64Field   @11 :Float64;
+  textField      @12 :Text;
+  dataField      @13 :Data;
+  structField    @14 :TestAllTypes;
+  enumField      @15 :TestEnum;
+  interfaceField @16 :Void;  # placeholder; interfaces not implemented in capnp-ts
+
+  voidList      @17 :List(Void);
+  boolList      @18 :List(Bool);
+  int8List      @19 :List(Int8);
+  int16List     @20 :List(Int16);
+  int32List     @21 :List(Int32);
+  int64List     @22 :List(Int64);
+  uInt8List     @23 :List(UInt8);
+  uInt16List    @24 :List(UInt16);
+  uInt32List    @25 :List(UInt32);
+  uInt64List    @26 :List(UInt64);
+  float32List   @27 :List(Float32);
+  float64List   @28 :List(Float64);
+  textList      @29 :List(Text);
+  dataList      @30 :List(Data);
+  structList    @31 :List(TestAllTypes);
+  enumList      @32 :List(TestEnum);
+}

--- a/packages/capnp-ts-test/test/parity/parity-test.capnp
+++ b/packages/capnp-ts-test/test/parity/parity-test.capnp
@@ -53,3 +53,46 @@ struct TestAllTypes {
   structList    @31 :List(TestAllTypes);
   enumList      @32 :List(TestEnum);
 }
+
+struct TestDefaults {
+  voidField      @0  :Void    = void;
+  boolField      @1  :Bool    = true;
+  int8Field      @2  :Int8    = -123;
+  int16Field     @3  :Int16   = -12345;
+  int32Field     @4  :Int32   = -12345678;
+  int64Field     @5  :Int64   = -123456789012345;
+  uInt8Field     @6  :UInt8   = 234;
+  uInt16Field    @7  :UInt16  = 45678;
+  uInt32Field    @8  :UInt32  = 3456789012;
+  uInt64Field    @9  :UInt64  = 12345678901234567890;
+  float32Field   @10 :Float32 = 1234.5;
+  float64Field   @11 :Float64 = -123e45;
+  textField      @12 :Text    = "foo";
+  dataField      @13 :Data    = 0x"62 61 72";
+  structField    @14 :TestAllTypes = (
+      textField = "nested",
+      structField = (textField = "really nested"),
+      enumField = baz);
+  enumField      @15 :TestEnum = corge;
+  interfaceField @16 :Void;
+
+  voidList      @17 :List(Void)    = [void, void, void];
+  boolList      @18 :List(Bool)    = [true, false];
+  int8List      @19 :List(Int8)    = [111, -111];
+  int16List     @20 :List(Int16)   = [11111, -11111];
+  int32List     @21 :List(Int32)   = [111111111, -111111111];
+  int64List     @22 :List(Int64)   = [1111111111111111111, -1111111111111111111];
+  uInt8List     @23 :List(UInt8)   = [111, 222];
+  uInt16List    @24 :List(UInt16)  = [33333, 44444];
+  uInt32List    @25 :List(UInt32)  = [3333333333];
+  uInt64List    @26 :List(UInt64)  = [11111111111111111111];
+  float32List   @27 :List(Float32) = [5555.5, inf, -inf, nan];
+  float64List   @28 :List(Float64) = [7777.75, inf, -inf, nan];
+  textList      @29 :List(Text)    = ["plugh", "xyzzy", "thud"];
+  dataList      @30 :List(Data)    = ["oops", "exhausted", "rfc3092"];
+  structList    @31 :List(TestAllTypes) = [
+      (textField = "structlist 1"),
+      (textField = "structlist 2"),
+      (textField = "structlist 3")];
+  enumList      @32 :List(TestEnum) = [foo, garply];
+}

--- a/packages/capnp-ts-test/test/parity/parity.spec.ts
+++ b/packages/capnp-ts-test/test/parity/parity.spec.ts
@@ -1,107 +1,269 @@
 import * as capnp from "capnp-ts";
 import { spawnSync } from "child_process";
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
-import * as os from "os";
-import * as path from "path";
 import tap from "tap";
 
-import { TestAllTypes, TestEnum } from "./parity-test.capnp.js";
+import "./parity-test.capnp.js";
 
-const SCHEMA = path.join(__dirname, "parity-test.capnp");
+const SCHEMA_DIR = __dirname;
+const SCHEMA_FILE = "parity-test.capnp";
+
+function spawn(args: string[], input?: Buffer): Buffer {
+  const res = spawnSync("capnp", args, {
+    cwd: SCHEMA_DIR,
+    input,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (res.status !== 0) {
+    throw new Error(`capnp ${args.join(" ")} failed: ${res.stderr.toString()}`);
+  }
+  return res.stdout;
+}
+
+function toArrayBuffer(buf: Buffer): ArrayBuffer {
+  const ab = new ArrayBuffer(buf.byteLength);
+  new Uint8Array(ab).set(buf);
+  return ab;
+}
 
 function capnpEncode(text: string, rootType: string, packed = false): ArrayBuffer {
   const args = ["encode"];
   if (packed) args.push("--packed");
-  args.push(SCHEMA, rootType);
-  const res = spawnSync("capnp", args, { input: text });
-  if (res.status !== 0) {
-    throw new Error(`capnp encode failed: ${res.stderr.toString()}`);
-  }
-  return res.stdout.buffer.slice(res.stdout.byteOffset, res.stdout.byteOffset + res.stdout.byteLength);
+  args.push(SCHEMA_FILE, rootType);
+  return toArrayBuffer(spawn(args, Buffer.from(text)));
 }
 
 function capnpDecode(buf: ArrayBuffer, rootType: string, packed = false): string {
   const args = ["decode"];
   if (packed) args.push("--packed");
-  args.push(SCHEMA, rootType);
-  const res = spawnSync("capnp", args, { input: Buffer.from(buf) });
-  if (res.status !== 0) {
-    throw new Error(`capnp decode failed: ${res.stderr.toString()}`);
-  }
-  return res.stdout.toString();
+  args.push(SCHEMA_FILE, rootType);
+  return spawn(args, Buffer.from(buf)).toString();
 }
 
-// Skip the whole suite if capnp is not on PATH (e.g. running outside the nix devShell).
-const HAS_CAPNP = spawnSync("capnp", ["--version"]).status === 0;
+function buffersEqual(a: ArrayBuffer, b: ArrayBuffer): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  const ua = new Uint8Array(a);
+  const ub = new Uint8Array(b);
+  for (let i = 0; i < ua.byteLength; i++) if (ua[i] !== ub[i]) return false;
+  return true;
+}
 
-tap.test("parity", { skip: !HAS_CAPNP ? "capnp binary not on PATH" : undefined }, (t) => {
-  void t.test("read: TestAllTypes with int32Field=42, textField=hello, enumField=baz", (t) => {
-    const ref = capnpEncode(`(int32Field = 42, textField = "hello", enumField = baz)`, "TestAllTypes");
-    const m = new capnp.Message(ref, false);
-    const r = m.getRoot(TestAllTypes);
+const HAS_CAPNP = spawnSync("capnp", ["--version"], { cwd: SCHEMA_DIR }).status === 0;
 
-    t.equal(r.getInt32Field(), 42);
-    t.equal(r.getTextField(), "hello");
-    t.equal(r.getEnumField(), TestEnum.BAZ);
+interface Case {
+  name: string;
+  type: string;
+  text: string;
+}
 
-    t.end();
-  });
+const CASES: Case[] = [
+  {
+    name: "TestAllTypes: empty (all defaults are zero/false/null)",
+    type: "TestAllTypes",
+    text: `()`,
+  },
+  {
+    name: "TestAllTypes: bool + every integer width",
+    type: "TestAllTypes",
+    text: `(boolField = true, int8Field = -1, int16Field = -2, int32Field = -3, int64Field = -4, uInt8Field = 1, uInt16Field = 2, uInt32Field = 3, uInt64Field = 4)`,
+  },
+  {
+    name: "TestAllTypes: integer extremes",
+    type: "TestAllTypes",
+    text: `(int8Field = -128, int16Field = -32768, int32Field = -2147483648, int64Field = -9223372036854775808, uInt8Field = 255, uInt16Field = 65535, uInt32Field = 4294967295, uInt64Field = 18446744073709551615)`,
+  },
+  {
+    name: "TestAllTypes: integer extremes (max positive signed)",
+    type: "TestAllTypes",
+    text: `(int8Field = 127, int16Field = 32767, int32Field = 2147483647, int64Field = 9223372036854775807)`,
+  },
+  {
+    name: "TestAllTypes: floats with sign + magnitude",
+    type: "TestAllTypes",
+    text: `(float32Field = 1234.5, float64Field = -123e45)`,
+  },
+  {
+    name: "TestAllTypes: float special values (nan, inf, -inf)",
+    type: "TestAllTypes",
+    text: `(float32Field = nan, float64Field = inf)`,
+  },
+  {
+    name: "TestAllTypes: float extremes",
+    type: "TestAllTypes",
+    text: `(float32Field = 3.402823e38, float64Field = 1.7976931348623157e308)`,
+  },
+  {
+    name: "TestAllTypes: float denormals",
+    type: "TestAllTypes",
+    text: `(float32Field = 1e-38, float64Field = 5e-324)`,
+  },
+  {
+    name: "TestAllTypes: text (ASCII)",
+    type: "TestAllTypes",
+    text: `(textField = "hello world")`,
+  },
+  {
+    name: "TestAllTypes: text (multibyte UTF-8)",
+    type: "TestAllTypes",
+    text: `(textField = "♫ é ✓ 漢字")`,
+  },
+  {
+    name: "TestAllTypes: text (empty)",
+    type: "TestAllTypes",
+    text: `(textField = "")`,
+  },
+  {
+    name: "TestAllTypes: data",
+    type: "TestAllTypes",
+    text: `(dataField = "abcd")`,
+  },
+  {
+    name: "TestAllTypes: data (with non-ASCII bytes)",
+    type: "TestAllTypes",
+    text: `(dataField = 0x"00 ff 7e 80")`,
+  },
+  {
+    name: "TestAllTypes: enum (each value)",
+    type: "TestAllTypes",
+    text: `(enumField = foo)`,
+  },
+  {
+    name: "TestAllTypes: nested struct (1 level)",
+    type: "TestAllTypes",
+    text: `(structField = (int32Field = 42, textField = "nested"))`,
+  },
+  {
+    name: "TestAllTypes: deeply nested struct (3 levels)",
+    type: "TestAllTypes",
+    text: `(structField = (structField = (structField = (int32Field = 1, textField = "deep"))))`,
+  },
+  {
+    name: "TestAllTypes: void list",
+    type: "TestAllTypes",
+    text: `(voidList = [void, void, void, void, void])`,
+  },
+  {
+    name: "TestAllTypes: bool list (bit-packed)",
+    type: "TestAllTypes",
+    text: `(boolList = [true, false, true, true, false, true, false, false, true])`,
+  },
+  {
+    name: "TestAllTypes: int8 list with extremes",
+    type: "TestAllTypes",
+    text: `(int8List = [-128, 127, 0, -1, 1])`,
+  },
+  {
+    name: "TestAllTypes: int16 list with extremes",
+    type: "TestAllTypes",
+    text: `(int16List = [-32768, 32767, 0])`,
+  },
+  {
+    name: "TestAllTypes: int32 list with extremes",
+    type: "TestAllTypes",
+    text: `(int32List = [-2147483648, 2147483647, 0])`,
+  },
+  {
+    name: "TestAllTypes: int64 list with extremes",
+    type: "TestAllTypes",
+    text: `(int64List = [-9223372036854775808, 9223372036854775807, 0])`,
+  },
+  {
+    name: "TestAllTypes: uint8 list with extremes",
+    type: "TestAllTypes",
+    text: `(uInt8List = [0, 255, 128])`,
+  },
+  {
+    name: "TestAllTypes: uint16 list with extremes",
+    type: "TestAllTypes",
+    text: `(uInt16List = [0, 65535, 32768])`,
+  },
+  {
+    name: "TestAllTypes: uint32 list with extremes",
+    type: "TestAllTypes",
+    text: `(uInt32List = [0, 4294967295, 2147483648])`,
+  },
+  {
+    name: "TestAllTypes: uint64 list with extremes",
+    type: "TestAllTypes",
+    text: `(uInt64List = [0, 18446744073709551615, 9223372036854775808])`,
+  },
+  {
+    name: "TestAllTypes: float32 list with special values",
+    type: "TestAllTypes",
+    text: `(float32List = [0, 1.0, -1.0, nan, inf, -inf])`,
+  },
+  {
+    name: "TestAllTypes: float64 list with special values",
+    type: "TestAllTypes",
+    text: `(float64List = [0, 1.0, -1.0, nan, inf, -inf])`,
+  },
+  {
+    name: "TestAllTypes: text list",
+    type: "TestAllTypes",
+    text: `(textList = ["foo", "bar", "baz", ""])`,
+  },
+  {
+    name: "TestAllTypes: data list",
+    type: "TestAllTypes",
+    text: `(dataList = ["abc", "def", 0x"00 01"])`,
+  },
+  {
+    name: "TestAllTypes: struct list (composite)",
+    type: "TestAllTypes",
+    text: `(structList = [(int32Field = 1), (int32Field = 2), (int32Field = 3)])`,
+  },
+  {
+    name: "TestAllTypes: enum list",
+    type: "TestAllTypes",
+    text: `(enumList = [foo, bar, baz, qux, quux, corge, grault, garply])`,
+  },
+  {
+    name: "TestAllTypes: every field populated",
+    type: "TestAllTypes",
+    text: `(voidField = void, boolField = true, int8Field = -128, int16Field = -32768, int32Field = -2147483648, int64Field = -9223372036854775808, uInt8Field = 255, uInt16Field = 65535, uInt32Field = 4294967295, uInt64Field = 18446744073709551615, float32Field = 1234.5, float64Field = -123e45, textField = "everything", dataField = "data", structField = (int32Field = 99), enumField = garply, voidList = [void], boolList = [true, false], int8List = [1, -1], int16List = [2, -2], int32List = [3, -3], int64List = [4, -4], uInt8List = [5, 6], uInt16List = [7, 8], uInt32List = [9, 10], uInt64List = [11, 12], float32List = [1.5, -2.5], float64List = [3.5, -4.5], textList = ["a", "b"], dataList = ["c", "d"], structList = [(int32Field = 1)], enumList = [foo, bar])`,
+  },
+  {
+    name: "TestDefaults: empty (defaults fill in via XOR mask)",
+    type: "TestDefaults",
+    text: `()`,
+  },
+  {
+    name: "TestDefaults: override every field",
+    type: "TestDefaults",
+    text: `(boolField = false, int8Field = 0, int16Field = 0, int32Field = 0, int64Field = 0, uInt8Field = 0, uInt16Field = 0, uInt32Field = 0, uInt64Field = 0, float32Field = 0, float64Field = 0, textField = "", dataField = "", structField = (int32Field = 1), enumField = foo, voidList = [], boolList = [], int8List = [], int16List = [], int32List = [], int64List = [], uInt8List = [], uInt16List = [], uInt32List = [], uInt64List = [], float32List = [], float64List = [], textList = [], dataList = [], structList = [], enumList = [])`,
+  },
+  {
+    name: "TestDefaults: partial override (mix of defaults and values)",
+    type: "TestDefaults",
+    text: `(int32Field = 42, textField = "override", enumField = garply)`,
+  },
+];
 
-  void t.test("write: TestAllTypes round-trip via capnp-ts produces identical unpacked bytes", (t) => {
-    const ref = capnpEncode(`(int32Field = 42, textField = "hello", enumField = baz)`, "TestAllTypes");
+tap.test("parity against C++ reference implementation", { skip: !HAS_CAPNP ? "capnp binary not on PATH" : undefined }, (t) => {
+  for (const c of CASES) {
+    void t.test(c.name, (t) => {
+      const refUnpacked = capnpEncode(c.text, c.type, false);
+      const refPacked = capnpEncode(c.text, c.type, true);
+      const refText = capnpDecode(refUnpacked, c.type);
 
-    const m = new capnp.Message();
-    const r = m.initRoot(TestAllTypes);
-    r.setInt32Field(42);
-    r.setTextField("hello");
-    r.setEnumField(TestEnum.BAZ);
+      // Read parity: C++ unpacked bytes -> capnp-ts reads -> re-serializes -> byte-exact match.
+      const m1 = new capnp.Message(refUnpacked.slice(0), false);
+      const out1 = m1.toArrayBuffer();
+      t.ok(buffersEqual(out1, refUnpacked), "unpacked round trip preserves bytes");
 
-    const out = m.toArrayBuffer();
+      // Cross-format: C++ packed -> capnp-ts unpacks -> re-serializes unpacked -> matches C++ unpacked.
+      const m2 = new capnp.Message(refPacked.slice(0));
+      const out2 = m2.toArrayBuffer();
+      t.ok(buffersEqual(out2, refUnpacked), "C++-packed -> ts -> unpacked matches C++ unpacked");
 
-    // compareBuffers would be ideal here but it's in the test/util module;
-    // a direct byte comparison is fine for parity.
-    t.equal(out.byteLength, ref.byteLength, "byte lengths should match");
-    if (out.byteLength === ref.byteLength) {
-      const a = new Uint8Array(out);
-      const b = new Uint8Array(ref);
-      let mismatch = -1;
-      for (let i = 0; i < a.byteLength; i++) {
-        if (a[i] !== b[i]) { mismatch = i; break; }
-      }
-      t.equal(mismatch, -1, `bytes should match (first mismatch at ${mismatch})`);
-    }
+      // Cross-format: C++ unpacked -> capnp-ts packs -> C++ unpacks -> text matches.
+      const m3 = new capnp.Message(refUnpacked.slice(0), false);
+      const out3packed = m3.toPackedArrayBuffer();
+      const text3 = capnpDecode(out3packed, c.type, true);
+      t.equal(text3, refText, "ts-packed round trips through C++ decode");
 
-    t.end();
-  });
-
-  void t.test("packed round-trip: ts writes packed, C++ unpacks, values match", (t) => {
-    const m = new capnp.Message();
-    const r = m.initRoot(TestAllTypes);
-    r.setInt32Field(42);
-    r.setTextField("hello");
-    r.setEnumField(TestEnum.BAZ);
-
-    const packed = m.toPackedArrayBuffer();
-    const text = capnpDecode(packed, "TestAllTypes", true);
-
-    t.match(text, /int32Field = 42/);
-    t.match(text, /textField = "hello"/);
-    t.match(text, /enumField = baz/);
-
-    t.end();
-  });
-
-  void t.test("packed round-trip: C++ writes packed, ts unpacks, values match", (t) => {
-    const packed = capnpEncode(`(int32Field = 42, textField = "hello", enumField = baz)`, "TestAllTypes", true);
-    const m = new capnp.Message(packed); // default packed=true
-    const r = m.getRoot(TestAllTypes);
-
-    t.equal(r.getInt32Field(), 42);
-    t.equal(r.getTextField(), "hello");
-    t.equal(r.getEnumField(), TestEnum.BAZ);
-
-    t.end();
-  });
+      t.end();
+    });
+  }
 
   t.end();
 });

--- a/packages/capnp-ts-test/test/parity/parity.spec.ts
+++ b/packages/capnp-ts-test/test/parity/parity.spec.ts
@@ -1,53 +1,12 @@
+import * as path from "path";
 import * as capnp from "capnp-ts";
-import { spawnSync } from "child_process";
 import tap from "tap";
+
+import { capnpDecode, capnpEncode, compareBuffers, hasCapnp } from "../util";
 
 import "./parity-test.capnp.js";
 
-const SCHEMA_DIR = __dirname;
-const SCHEMA_FILE = "parity-test.capnp";
-
-function spawn(args: string[], input?: Buffer): Buffer {
-  const res = spawnSync("capnp", args, {
-    cwd: SCHEMA_DIR,
-    input,
-    maxBuffer: 64 * 1024 * 1024,
-  });
-  if (res.status !== 0) {
-    throw new Error(`capnp ${args.join(" ")} failed: ${res.stderr.toString()}`);
-  }
-  return res.stdout;
-}
-
-function toArrayBuffer(buf: Buffer): ArrayBuffer {
-  const ab = new ArrayBuffer(buf.byteLength);
-  new Uint8Array(ab).set(buf);
-  return ab;
-}
-
-function capnpEncode(text: string, rootType: string, packed = false): ArrayBuffer {
-  const args = ["encode"];
-  if (packed) args.push("--packed");
-  args.push(SCHEMA_FILE, rootType);
-  return toArrayBuffer(spawn(args, Buffer.from(text)));
-}
-
-function capnpDecode(buf: ArrayBuffer, rootType: string, packed = false): string {
-  const args = ["decode"];
-  if (packed) args.push("--packed");
-  args.push(SCHEMA_FILE, rootType);
-  return spawn(args, Buffer.from(buf)).toString();
-}
-
-function buffersEqual(a: ArrayBuffer, b: ArrayBuffer): boolean {
-  if (a.byteLength !== b.byteLength) return false;
-  const ua = new Uint8Array(a);
-  const ub = new Uint8Array(b);
-  for (let i = 0; i < ua.byteLength; i++) if (ua[i] !== ub[i]) return false;
-  return true;
-}
-
-const HAS_CAPNP = spawnSync("capnp", ["--version"], { cwd: SCHEMA_DIR }).status === 0;
+const SCHEMA = path.join(__dirname, "parity-test.capnp");
 
 interface Case {
   name: string;
@@ -238,32 +197,31 @@ const CASES: Case[] = [
   },
 ];
 
-tap.test("parity against C++ reference implementation", { skip: !HAS_CAPNP ? "capnp binary not on PATH" : undefined }, (t) => {
-  for (const c of CASES) {
-    void t.test(c.name, (t) => {
-      const refUnpacked = capnpEncode(c.text, c.type, false);
-      const refPacked = capnpEncode(c.text, c.type, true);
-      const refText = capnpDecode(refUnpacked, c.type);
+void tap.test(
+  "parity against C++ reference implementation",
+  { skip: !hasCapnp() ? "capnp binary not on PATH" : undefined },
+  (t) => {
+    for (const c of CASES) {
+      void t.test(c.name, (t) => {
+        const refUnpacked = capnpEncode(SCHEMA, c.text, c.type, false);
+        const refPacked = capnpEncode(SCHEMA, c.text, c.type, true);
+        const refText = capnpDecode(SCHEMA, refUnpacked, c.type);
 
-      // Read parity: C++ unpacked bytes -> capnp-ts reads -> re-serializes -> byte-exact match.
-      const m1 = new capnp.Message(refUnpacked.slice(0), false);
-      const out1 = m1.toArrayBuffer();
-      t.ok(buffersEqual(out1, refUnpacked), "unpacked round trip preserves bytes");
+        const m1 = new capnp.Message(refUnpacked.slice(0), false);
+        compareBuffers(t, m1.toArrayBuffer(), refUnpacked, "unpacked round trip preserves bytes");
 
-      // Cross-format: C++ packed -> capnp-ts unpacks -> re-serializes unpacked -> matches C++ unpacked.
-      const m2 = new capnp.Message(refPacked.slice(0));
-      const out2 = m2.toArrayBuffer();
-      t.ok(buffersEqual(out2, refUnpacked), "C++-packed -> ts -> unpacked matches C++ unpacked");
+        const m2 = new capnp.Message(refPacked.slice(0));
+        compareBuffers(t, m2.toArrayBuffer(), refUnpacked, "C++-packed -> ts -> unpacked matches C++ unpacked");
 
-      // Cross-format: C++ unpacked -> capnp-ts packs -> C++ unpacks -> text matches.
-      const m3 = new capnp.Message(refUnpacked.slice(0), false);
-      const out3packed = m3.toPackedArrayBuffer();
-      const text3 = capnpDecode(out3packed, c.type, true);
-      t.equal(text3, refText, "ts-packed round trips through C++ decode");
+        const m3 = new capnp.Message(refUnpacked.slice(0), false);
+        const tsPacked = m3.toPackedArrayBuffer();
+        const text3 = capnpDecode(SCHEMA, tsPacked, c.type, true);
+        t.equal(text3, refText, "ts-packed round trips through C++ decode");
 
-      t.end();
-    });
-  }
+        t.end();
+      });
+    }
 
-  t.end();
-});
+    t.end();
+  },
+);

--- a/packages/capnp-ts-test/test/parity/parity.spec.ts
+++ b/packages/capnp-ts-test/test/parity/parity.spec.ts
@@ -1,0 +1,107 @@
+import * as capnp from "capnp-ts";
+import { spawnSync } from "child_process";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
+import * as os from "os";
+import * as path from "path";
+import tap from "tap";
+
+import { TestAllTypes, TestEnum } from "./parity-test.capnp.js";
+
+const SCHEMA = path.join(__dirname, "parity-test.capnp");
+
+function capnpEncode(text: string, rootType: string, packed = false): ArrayBuffer {
+  const args = ["encode"];
+  if (packed) args.push("--packed");
+  args.push(SCHEMA, rootType);
+  const res = spawnSync("capnp", args, { input: text });
+  if (res.status !== 0) {
+    throw new Error(`capnp encode failed: ${res.stderr.toString()}`);
+  }
+  return res.stdout.buffer.slice(res.stdout.byteOffset, res.stdout.byteOffset + res.stdout.byteLength);
+}
+
+function capnpDecode(buf: ArrayBuffer, rootType: string, packed = false): string {
+  const args = ["decode"];
+  if (packed) args.push("--packed");
+  args.push(SCHEMA, rootType);
+  const res = spawnSync("capnp", args, { input: Buffer.from(buf) });
+  if (res.status !== 0) {
+    throw new Error(`capnp decode failed: ${res.stderr.toString()}`);
+  }
+  return res.stdout.toString();
+}
+
+// Skip the whole suite if capnp is not on PATH (e.g. running outside the nix devShell).
+const HAS_CAPNP = spawnSync("capnp", ["--version"]).status === 0;
+
+tap.test("parity", { skip: !HAS_CAPNP ? "capnp binary not on PATH" : undefined }, (t) => {
+  void t.test("read: TestAllTypes with int32Field=42, textField=hello, enumField=baz", (t) => {
+    const ref = capnpEncode(`(int32Field = 42, textField = "hello", enumField = baz)`, "TestAllTypes");
+    const m = new capnp.Message(ref, false);
+    const r = m.getRoot(TestAllTypes);
+
+    t.equal(r.getInt32Field(), 42);
+    t.equal(r.getTextField(), "hello");
+    t.equal(r.getEnumField(), TestEnum.BAZ);
+
+    t.end();
+  });
+
+  void t.test("write: TestAllTypes round-trip via capnp-ts produces identical unpacked bytes", (t) => {
+    const ref = capnpEncode(`(int32Field = 42, textField = "hello", enumField = baz)`, "TestAllTypes");
+
+    const m = new capnp.Message();
+    const r = m.initRoot(TestAllTypes);
+    r.setInt32Field(42);
+    r.setTextField("hello");
+    r.setEnumField(TestEnum.BAZ);
+
+    const out = m.toArrayBuffer();
+
+    // compareBuffers would be ideal here but it's in the test/util module;
+    // a direct byte comparison is fine for parity.
+    t.equal(out.byteLength, ref.byteLength, "byte lengths should match");
+    if (out.byteLength === ref.byteLength) {
+      const a = new Uint8Array(out);
+      const b = new Uint8Array(ref);
+      let mismatch = -1;
+      for (let i = 0; i < a.byteLength; i++) {
+        if (a[i] !== b[i]) { mismatch = i; break; }
+      }
+      t.equal(mismatch, -1, `bytes should match (first mismatch at ${mismatch})`);
+    }
+
+    t.end();
+  });
+
+  void t.test("packed round-trip: ts writes packed, C++ unpacks, values match", (t) => {
+    const m = new capnp.Message();
+    const r = m.initRoot(TestAllTypes);
+    r.setInt32Field(42);
+    r.setTextField("hello");
+    r.setEnumField(TestEnum.BAZ);
+
+    const packed = m.toPackedArrayBuffer();
+    const text = capnpDecode(packed, "TestAllTypes", true);
+
+    t.match(text, /int32Field = 42/);
+    t.match(text, /textField = "hello"/);
+    t.match(text, /enumField = baz/);
+
+    t.end();
+  });
+
+  void t.test("packed round-trip: C++ writes packed, ts unpacks, values match", (t) => {
+    const packed = capnpEncode(`(int32Field = 42, textField = "hello", enumField = baz)`, "TestAllTypes", true);
+    const m = new capnp.Message(packed); // default packed=true
+    const r = m.getRoot(TestAllTypes);
+
+    t.equal(r.getInt32Field(), 42);
+    t.equal(r.getTextField(), "hello");
+    t.equal(r.getEnumField(), TestEnum.BAZ);
+
+    t.end();
+  });
+
+  t.end();
+});

--- a/packages/capnp-ts-test/test/unit/serialization/packing.spec.ts
+++ b/packages/capnp-ts-test/test/unit/serialization/packing.spec.ts
@@ -124,7 +124,9 @@ void tap.test("pack()", (t) => {
 
 void tap.test("unpack()", (t) => {
   PACKING_DATA.forEach(({ name, packed, unpacked }) => {
-    compareBuffers(t, unpack(packed), unpacked, name);
+    const dst = new Uint8Array(new ArrayBuffer(getUnpackedByteLength(packed)));
+    unpack(new Uint8Array(packed), 0, dst);
+    compareBuffers(t, dst.buffer, unpacked, name);
   });
 
   t.end();

--- a/packages/capnp-ts-test/test/util/index.ts
+++ b/packages/capnp-ts-test/test/util/index.ts
@@ -1,4 +1,5 @@
 import Benchmark, { Suite } from "benchmark";
+import { spawnSync } from "child_process";
 import { readFileSync } from "fs";
 import * as path from "path";
 import { check, CheckOptions, Property } from "testcheck";
@@ -114,4 +115,38 @@ export function runTestCheck<TArgs>(
 
     t.end();
   });
+}
+
+export function hasCapnp(): boolean {
+  return spawnSync("capnp", ["--version"]).status === 0;
+}
+
+export function capnpEncode(schemaPath: string, text: string, rootType: string, packed = false): ArrayBuffer {
+  const args = ["encode"];
+  if (packed) args.push("--packed");
+  args.push(schemaPath, rootType);
+  const res = spawnSync("capnp", args, {
+    input: Buffer.from(text),
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (res.status !== 0) {
+    throw new Error(`capnp encode failed: ${res.stderr.toString()}`);
+  }
+  const ab = new ArrayBuffer(res.stdout.byteLength);
+  new Uint8Array(ab).set(res.stdout);
+  return ab;
+}
+
+export function capnpDecode(schemaPath: string, buf: ArrayBuffer, rootType: string, packed = false): string {
+  const args = ["decode"];
+  if (packed) args.push("--packed");
+  args.push(schemaPath, rootType);
+  const res = spawnSync("capnp", args, {
+    input: Buffer.from(buf),
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (res.status !== 0) {
+    throw new Error(`capnp decode failed: ${res.stderr.toString()}`);
+  }
+  return res.stdout.toString();
 }

--- a/packages/capnp-ts/README.md
+++ b/packages/capnp-ts/README.md
@@ -7,11 +7,11 @@ Here's a quick usage example:
 ```typescript
 import * as capnp from 'capnp-ts';
 
-import {MyStruct} from './myschema.capnp';
+import {MyStruct} from './myschema.capnp.js';
 
 export function loadMessage(buffer: ArrayBuffer): MyStruct {
 
-  const message = capnp.Message.fromArrayBuffer(buffer);
+  const message = new capnp.Message(buffer, false);
 
   return message.getRoot(MyStruct);
 

--- a/packages/capnp-ts/src/serialization/message.ts
+++ b/packages/capnp-ts/src/serialization/message.ts
@@ -12,7 +12,7 @@ import {
 } from "../errors";
 import { dumpBuffer, format, padToWord } from "../util";
 import { AnyArena, Arena, MultiSegmentArena, SingleSegmentArena, ArenaKind } from "./arena";
-import { pack, unpack, getUnpackedByteLength } from "./packing";
+import { pack, unpack, getUnpackedByteLength, PackedReader } from "./packing";
 import { Pointer, StructCtor, PointerType, Struct } from "./pointers";
 import { Segment } from "./segment";
 import { getTargetStructSize, validate } from "./pointers/pointer";
@@ -204,11 +204,22 @@ export function initMessage(
   }
 
   if (packed) {
-    const len = getUnpackedByteLength(buf);
-    const srcArr = new Uint8Array(buf);
-    const dst = new Uint8Array(new ArrayBuffer(len));
-    unpack(srcArr, 0, dst);
-    buf = dst.buffer;
+    if (singleSegment) {
+      const len = getUnpackedByteLength(buf);
+      const srcArr = new Uint8Array(buf);
+      const dst = new Uint8Array(new ArrayBuffer(len));
+      unpack(srcArr, 0, dst);
+      return {
+        arena: new SingleSegmentArena(dst.buffer),
+        segments: [],
+        traversalLimit: DEFAULT_TRAVERSE_LIMIT,
+      };
+    }
+    return {
+      arena: new MultiSegmentArena(unpackFramedSegments(new Uint8Array(buf))),
+      segments: [],
+      traversalLimit: DEFAULT_TRAVERSE_LIMIT,
+    };
   }
 
   if (singleSegment) {
@@ -263,6 +274,36 @@ export function getFramedSegments(message: ArrayBuffer): ArrayBuffer[] {
     segments[i] = message.slice(byteOffset, byteOffset + byteLength);
 
     byteOffset += byteLength;
+  }
+
+  return segments;
+}
+
+export function unpackFramedSegments(src: Uint8Array): ArrayBuffer[] {
+  const reader = new PackedReader(src);
+
+  const firstWord = new Uint8Array(8);
+  reader.read(firstWord);
+  const segmentCount = new DataView(firstWord.buffer).getUint32(0, true) + 1;
+
+  const headerContentBytes = 4 + segmentCount * 4;
+  const headerWords = Math.ceil(headerContentBytes / 8);
+  const headerPadded = headerWords * 8;
+
+  const header = new Uint8Array(headerPadded);
+  header.set(firstWord);
+  if (headerPadded > 8) {
+    reader.read(header.subarray(8));
+  }
+
+  const hdv = new DataView(header.buffer);
+  const segments: ArrayBuffer[] = new Array(segmentCount);
+
+  for (let i = 0; i < segmentCount; i++) {
+    const wordCount = hdv.getUint32(4 + i * 4, true);
+    const segDst = new Uint8Array(new ArrayBuffer(wordCount * 8));
+    reader.read(segDst);
+    segments[i] = segDst.buffer;
   }
 
   return segments;

--- a/packages/capnp-ts/src/serialization/message.ts
+++ b/packages/capnp-ts/src/serialization/message.ts
@@ -12,7 +12,7 @@ import {
 } from "../errors";
 import { dumpBuffer, format, padToWord } from "../util";
 import { AnyArena, Arena, MultiSegmentArena, SingleSegmentArena, ArenaKind } from "./arena";
-import { pack, unpack } from "./packing";
+import { pack, unpack, getUnpackedByteLength } from "./packing";
 import { Pointer, StructCtor, PointerType, Struct } from "./pointers";
 import { Segment } from "./segment";
 import { getTargetStructSize, validate } from "./pointers/pointer";
@@ -203,7 +203,13 @@ export function initMessage(
     buf = src;
   }
 
-  if (packed) buf = unpack(buf);
+  if (packed) {
+    const len = getUnpackedByteLength(buf);
+    const srcArr = new Uint8Array(buf);
+    const dst = new Uint8Array(new ArrayBuffer(len));
+    unpack(srcArr, 0, dst);
+    buf = dst.buffer;
+  }
 
   if (singleSegment) {
     return {

--- a/packages/capnp-ts/src/serialization/packing.ts
+++ b/packages/capnp-ts/src/serialization/packing.ts
@@ -315,33 +315,47 @@ export function pack(unpacked: ArrayBuffer, byteOffset = 0, byteLength?: number)
  */
 
 export function unpack(src: Uint8Array, srcOffset: number, dst: Uint8Array): number {
-  let si = srcOffset;
-  let di = 0;
-  const dstLen = dst.byteLength;
-  let lastTag = PackedTag.NONZERO_NONSPAN;
+  return new PackedReader(src, srcOffset).read(dst);
+}
 
-  while (di < dstLen) {
-    const tag = src[si];
+export class PackedReader {
+  private lastTag = PackedTag.NONZERO_NONSPAN;
 
-    if (lastTag === PackedTag.ZERO) {
-      di += tag * 8;
-      si++;
-      lastTag = PackedTag.NONZERO_NONSPAN;
-    } else if (lastTag === PackedTag.SPAN) {
-      const spanBytes = tag * 8;
-      dst.set(src.subarray(si + 1, si + 1 + spanBytes), di);
-      di += spanBytes;
-      si += 1 + spanBytes;
-      lastTag = PackedTag.NONZERO_NONSPAN;
-    } else {
-      si++;
-      for (let bit = 1; bit <= 0x80; bit <<= 1) {
-        if ((tag & bit) !== 0) dst[di] = src[si++];
-        di++;
+  constructor(private readonly src: Uint8Array, private offset = 0) {}
+
+  read(dst: Uint8Array): number {
+    const src = this.src;
+    const dstLen = dst.byteLength;
+    const start = this.offset;
+    let di = 0;
+    let si = this.offset;
+    let lastTag = this.lastTag;
+
+    while (di < dstLen) {
+      const tag = src[si];
+
+      if (lastTag === PackedTag.ZERO) {
+        di += tag * 8;
+        si++;
+        lastTag = PackedTag.NONZERO_NONSPAN;
+      } else if (lastTag === PackedTag.SPAN) {
+        const spanBytes = tag * 8;
+        dst.set(src.subarray(si + 1, si + 1 + spanBytes), di);
+        di += spanBytes;
+        si += 1 + spanBytes;
+        lastTag = PackedTag.NONZERO_NONSPAN;
+      } else {
+        si++;
+        for (let bit = 1; bit <= 0x80; bit <<= 1) {
+          if ((tag & bit) !== 0) dst[di] = src[si++];
+          di++;
+        }
+        lastTag = tag;
       }
-      lastTag = tag;
     }
-  }
 
-  return si - srcOffset;
+    this.offset = si;
+    this.lastTag = lastTag;
+    return si - start;
+  }
 }

--- a/packages/capnp-ts/src/serialization/packing.ts
+++ b/packages/capnp-ts/src/serialization/packing.ts
@@ -314,54 +314,34 @@ export function pack(unpacked: ArrayBuffer, byteOffset = 0, byteLength?: number)
  * @returns {ArrayBuffer} The unpacked message.
  */
 
-export function unpack(packed: ArrayBuffer): ArrayBuffer {
-  // We have no choice but to read the packed buffer one byte at a time.
-
-  const src = new Uint8Array(packed);
-  const dst = new Uint8Array(new ArrayBuffer(getUnpackedByteLength(packed)));
-
-  /** The last tag byte that we've seen - it starts at a "neutral" value. */
-
+export function unpack(src: Uint8Array, srcOffset: number, dst: Uint8Array): number {
+  let si = srcOffset;
+  let di = 0;
+  const dstLen = dst.byteLength;
   let lastTag = PackedTag.NONZERO_NONSPAN;
 
-  for (let srcByteOffset = 0, dstByteOffset = 0; srcByteOffset < src.byteLength; ) {
-    const tag = src[srcByteOffset];
+  while (di < dstLen) {
+    const tag = src[si];
 
     if (lastTag === PackedTag.ZERO) {
-      // We have a span of zeroes. New array buffers are guaranteed to be initialized to zero so we just seek ahead.
-
-      dstByteOffset += tag * 8;
-
-      srcByteOffset++;
-
+      di += tag * 8;
+      si++;
       lastTag = PackedTag.NONZERO_NONSPAN;
     } else if (lastTag === PackedTag.SPAN) {
-      // We have a span of unpacked bytes. Copy them verbatim from the source buffer.
-
-      const spanByteLength = tag * 8;
-
-      dst.set(src.subarray(srcByteOffset + 1, srcByteOffset + 1 + spanByteLength), dstByteOffset);
-
-      dstByteOffset += spanByteLength;
-      srcByteOffset += 1 + spanByteLength;
-
+      const spanBytes = tag * 8;
+      dst.set(src.subarray(si + 1, si + 1 + spanBytes), di);
+      di += spanBytes;
+      si += 1 + spanBytes;
       lastTag = PackedTag.NONZERO_NONSPAN;
     } else {
-      // Okay, a normal tag. Let's read past the tag and copy bytes that have a bit set in the tag.
-
-      srcByteOffset++;
-
-      for (let i = 1; i <= 0b10000000; i <<= 1) {
-        // We only need to actually touch `dst` if there's a nonzero byte (it's already initialized to zeroes).
-
-        if ((tag & i) !== 0) dst[dstByteOffset] = src[srcByteOffset++];
-
-        dstByteOffset++;
+      si++;
+      for (let bit = 1; bit <= 0x80; bit <<= 1) {
+        if ((tag & bit) !== 0) dst[di] = src[si++];
+        di++;
       }
-
       lastTag = tag;
     }
   }
 
-  return dst.buffer;
+  return si - srcOffset;
 }


### PR DESCRIPTION
Use a streaming approach (maintaining the last tag state) to build messages segment-by-segment, improving message loading performance significantly for packed message streams. Closes #69.

This patch introduces end-to-end tests to ensure byte-identical parity with (unpacked) messages generated by the reference C++ implementation.

New benchmarks were added to properly test shallow access patterns vs JSON.parse on larger payloads (only needing to sniff a few bytes off a relatively large payload streaming in at a high data rate is where capnp-ts really makes a difference).

```
Dataset: 1000 people x 3 phones each
  capnp: 184024 bytes, JSON: 139682 bytes

Starting benchmark: top level list length access
JSON.parse(decodeUtf8(m)) x 233,013 ops/sec ±0.93% (90 runs sampled)
JSON.parse(m) x 894,868 ops/sec ±0.54% (97 runs sampled)
capnp.Message(m) x 1,649,469 ops/sec ±0.64% (96 runs sampled)
Fastest top level list length access is capnp.Message(m) (7.079x faster)

Starting benchmark: "parse"
JSON.parse(decodeUtf8(m)) x 242,542 ops/sec ±0.84% (93 runs sampled)
JSON.parse(m) x 946,948 ops/sec ±0.31% (96 runs sampled)
capnp.Message(m).getRoot(A) x 5,579,824 ops/sec ±0.87% (97 runs sampled)
Fastest "parse" is capnp.Message(m).getRoot(A) (23.006x faster)

Starting benchmark: parse only (1000 people)
JSON.parse x 2,597 ops/sec ±0.64% (99 runs sampled)
capnp.Message (lazy) x 8,892,748 ops/sec ±0.51% (100 runs sampled)
Fastest parse only (1000 people) is capnp.Message (lazy) (3424.622x faster)

Starting benchmark: selective access (person #500 name only)
JSON.parse + access x 2,533 ops/sec ±0.84% (97 runs sampled)
capnp.Message + access x 877,586 ops/sec ±0.56% (97 runs sampled)
Fastest selective access (person #500 name only) is capnp.Message + access (346.406x faster)

Starting benchmark: list length only (1000 people)
JSON.parse + .length x 2,494 ops/sec ±0.73% (97 runs sampled)
capnp.Message + getLength() x 1,723,502 ops/sec ±0.57% (98 runs sampled)
Fastest list length only (1000 people) is capnp.Message + getLength() (691.023x faster)

Starting benchmark: full traversal (3000 phone records)
JSON.parse + traverse x 2,484 ops/sec ±0.54% (97 runs sampled)
capnp.Message + traverse x 455 ops/sec ±1.04% (93 runs sampled)
Fastest full traversal (3000 phone records) is JSON.parse + traverse (5.465x faster)
```