### PR TITLE
test: add circleci ci pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2.1
+
+jobs:
+  flake_check:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - run:
+          name: Install Nix
+          command: |
+            sudo curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sudo sh -s -- install linux --no-confirm --init none
+            sudo chown -R $(whoami) /nix
+      - run:
+          name: Run Flake Check
+          command: |
+            . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+            nix flake check
+
+workflows:
+  ci:
+    jobs:
+      - flake_check

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
 
       # To recompute when package-lock.json changes:
       #   nix run nixpkgs#prefetch-npm-deps -- package-lock.json
-      npmDepsHash = "sha256-ZoorbSMLSvrMMUdjQz53Gm729haq0K2yHM50/0h+UeQ=";
+      npmDepsHash = "sha256-oeNLod+US+j8/x+wAwRQZhZYjF1BvNn58mXxNYGQCaI=";
 
       pkgs = import nixpkgs {inherit system;};
 


### PR DESCRIPTION
Leaves most of the complexity up to the flake; this syncs PR status with the result of running `nix flake check` on the project.