### PR TITLE
fix: emit file scoped constants correctly

### DIFF
--- a/packages/capnp-ts-test/test/integration/constants.capnp
+++ b/packages/capnp-ts-test/test/integration/constants.capnp
@@ -1,0 +1,10 @@
+@0xc78a29e6b2c1f3d4;
+
+using Bar = import "import-bar.capnp";
+
+const answer :UInt16 = 42;
+const blob :Data = 0x"01 02 03";
+const greeting :Text = "hey";
+const numbers :List(Int32) = [1, 2, 3];
+const pi :Float64 = 3.14159;
+const someBaz :Bar.Baz = (bar = "hi");

--- a/packages/capnp-ts-test/test/integration/constants.spec.ts
+++ b/packages/capnp-ts-test/test/integration/constants.spec.ts
@@ -1,0 +1,18 @@
+import tap from "tap";
+import { answer, getBlob, getNumbers, getSomeBaz, greeting, pi } from "./constants.capnp.js";
+
+void tap.test("file-scoped constants", (t) => {
+  t.equal(answer, 42);
+  t.equal(greeting, "hey");
+  t.equal(pi, 3.14159);
+
+  t.strictSame(Array.from(getBlob().toUint8Array()), [1, 2, 3]);
+
+  const numberList = getNumbers();
+  t.equal(numberList.getLength(), 3);
+  t.equal(numberList.get(1), 2);
+
+  t.equal(getSomeBaz().getBar(), "hi");
+
+  t.end();
+});

--- a/packages/capnp-ts-test/test/integration/imports.spec.ts
+++ b/packages/capnp-ts-test/test/integration/imports.spec.ts
@@ -1,13 +1,22 @@
 import tap from "tap";
 import * as capnp from "capnp-ts";
-import { Baz } from "./import-bar.capnp.js";
-import { Foo } from "./import-foo.capnp.js";
+import { Baz, getFoo } from "./import-bar.capnp.js";
+import { Foo, getBaz } from "./import-foo.capnp.js";
 
 void tap.test("schema imports", (t) => {
   t.doesNotThrow(() => {
     new capnp.Message().initRoot(Baz).setBar("bar");
     new capnp.Message().initRoot(Foo).initBaz().setBar("bar");
   });
+
+  t.end();
+});
+
+void tap.test("file-scoped constants across circular imports", (t) => {
+  // import-foo and import-bar import each other; the constants must not observe partially-initialized modules.
+
+  t.equal(getBaz().getBar(), "");
+  t.doesNotThrow(() => getFoo().getBaz());
 
   t.end();
 });

--- a/packages/capnpc-ts/src/generators.ts
+++ b/packages/capnpc-ts/src/generators.ts
@@ -53,6 +53,48 @@ export function generateConcreteListInitializer(
   );
 }
 
+export function generateConstNode(ctx: CodeGeneratorFileContext, node: s.Node): void {
+  const constNode = node.getConst();
+  const name = getDisplayNamePrefix(node);
+  const value = createValueExpression(constNode.getValue());
+
+  // Pointer-typed constants are emitted as functions so the class wrapping the raw bytes is not resolved until the
+  // constant is first used; a module-scope value could observe partially-initialized imports in a dependency cycle.
+
+  switch (constNode.getType().which()) {
+    case s.Type.DATA:
+      ctx.sourceParts.push(`export function get${util.c2t(name)}(): capnp.Data {
+    return capnp.Data.fromPointer(${value});
+}`);
+
+      break;
+
+    case s.Type.LIST: {
+      const listClass = getConcreteListType(ctx, constNode.getType());
+      const jsType = getJsType(ctx, constNode.getType(), false);
+      ctx.sourceParts.push(`export function get${util.c2t(name)}(): ${jsType} {
+    const p = ${value};
+    return new (${listClass})(p.segment, p.byteOffset);
+}`);
+
+      break;
+    }
+
+    case s.Type.STRUCT: {
+      const structClass = getJsType(ctx, constNode.getType(), false);
+      ctx.sourceParts.push(`export function get${util.c2t(name)}(): ${structClass} {
+    const p = ${value};
+    return new ${structClass}(p.segment, p.byteOffset);
+}`);
+
+      break;
+    }
+
+    default:
+      ctx.sourceParts.push(`export const ${name} = ${value};`);
+  }
+}
+
 export function generateDefaultValue(field: s.Field): string {
   const name = field.getName();
   const slot = field.getSlot();
@@ -426,7 +468,10 @@ export function generateNode(ctx: CodeGeneratorFileContext, node: s.Node): void 
       break;
 
     case s.Node.CONST:
-      // Const nodes are generated along with the containing class, ignore these.
+      // Struct-scoped consts are generated as statics along with the containing class; file-scoped consts have no
+      // containing class and are emitted at module scope.
+
+      if (node.getScopeId() === ctx.file.getId()) generateConstNode(ctx, node);
 
       break;
 


### PR DESCRIPTION
Now primitives/text emit as export const, and pointer-typed constants emit as functions (getSomeBaz(): Baz) so class references resolve lazily.

Closes #113.