### PR TITLE
fix: emit valid paths for absolute schema imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ capnp_out := $(patsubst %.capnp,%.capnp.js,$(capnp_in))
 export PATH := $(CURDIR)/$(capnpc_ts)/bin:$(PATH)
 
 %.capnp.js: %.capnp $(capnp_deps)
-	$(capnp_bin) compile -ots -I $(CURDIR)/$(capnp_ts)/src/std $<
+	$(capnp_bin) compile -ots -I $(CURDIR)/$(capnp_ts)/src/std -I $(CURDIR)/$(capnp_ts_test)/test/integration $<
 
 .PHONY: benchmark
 benchmark: build

--- a/packages/capnp-ts-test/test/integration/abs-import-lib.capnp
+++ b/packages/capnp-ts-test/test/integration/abs-import-lib.capnp
@@ -1,0 +1,6 @@
+@0xd3a8f0aa8c1b4d11;
+
+struct AbsPoint {
+  x @0 :Float64;
+  y @1 :Float64;
+}

--- a/packages/capnp-ts-test/test/integration/abs-import.capnp
+++ b/packages/capnp-ts-test/test/integration/abs-import.capnp
@@ -1,0 +1,9 @@
+@0xb4c2e19d8fe23a71;
+
+# Absolute imports resolve against the compiler's -I search paths (see the capnp compile rule in the Makefile).
+
+using Lib = import "/abs-import-lib.capnp";
+
+struct AbsBox {
+  corner @0 :Lib.AbsPoint;
+}

--- a/packages/capnp-ts-test/test/integration/abs-import.spec.ts
+++ b/packages/capnp-ts-test/test/integration/abs-import.spec.ts
@@ -1,0 +1,12 @@
+import tap from "tap";
+import * as capnp from "capnp-ts";
+import { AbsBox } from "./abs-import.capnp.js";
+
+void tap.test("absolute schema imports", (t) => {
+  const box = new capnp.Message().initRoot(AbsBox);
+  box.initCorner().setX(1.5);
+
+  t.equal(box.getCorner().getX(), 1.5);
+
+  t.end();
+});

--- a/packages/capnpc-ts/src/generators.ts
+++ b/packages/capnpc-ts/src/generators.ts
@@ -371,6 +371,10 @@ export function generateNestedImports(ctx: CodeGeneratorFileContext): void {
 
     if (name.substr(0, 7) === "/capnp/") {
       importPath = `capnp-ts/src/std/${name.substr(7)}.js`;
+    } else if (name[0] === "/") {
+      // Absolute imports resolve against the compiler's -I search paths; emit them relative to the output directory
+      // and assume the imported schema's own output lands alongside it.
+      importPath = `.${name}.js`;
     } else {
       importPath = name[0] === "." ? `${name}.js` : `./${name}.js`;
     }


### PR DESCRIPTION
Absolute schema imports now emit `./lib-file.capnp.js` instead of the malformed `.//lib-file.capnp.js`, resolved relative to the output directory.

Closes #118.