### PR TITLE
fix: exclude TypeScript source files from npm tarballs

### DIFF
--- a/packages/capnp-ts/package.json
+++ b/packages/capnp-ts/package.json
@@ -11,6 +11,11 @@
   "engines": {
     "node": ">=20"
   },
+  "files": [
+    "src/**/*.js",
+    "src/**/*.js.map",
+    "src/**/*.d.ts"
+  ],
   "homepage": "https://github.com/jdiaz5513/capnp-ts#readme",
   "keywords": [
     "capnp",

--- a/packages/capnpc-ts/package.json
+++ b/packages/capnpc-ts/package.json
@@ -16,6 +16,12 @@
   "engines": {
     "node": ">=20"
   },
+  "files": [
+    "bin/**/*.js",
+    "src/**/*.js",
+    "src/**/*.js.map",
+    "src/**/*.d.ts"
+  ],
   "homepage": "https://github.com/jdiaz5513/capnp-ts#readme",
   "keywords": [
     "capnp",


### PR DESCRIPTION
Closes #168.