### PR TITLE
feat: add support for annotations

### DIFF
--- a/packages/capnp-ts-test/test/integration/annotated.capnp
+++ b/packages/capnp-ts-test/test/integration/annotated.capnp
@@ -1,0 +1,17 @@
+@0xd4c9b12f83a7e654;
+
+annotation tag @0xea88d419cd1a22c8 (file, struct, field) :Text;
+annotation weight @0xb5f27ed23bfae214 (field) :UInt32;
+
+$tag("file-note");
+
+struct Widget $tag("widget") {
+  name @0 :Text $tag("name") $weight(42);
+  size @1 :UInt32;
+}
+
+# Applying the same annotation twice to one target is legal; metadata must preserve every application.
+
+struct Crate $tag("first") $tag("second") {
+  contents @0 :Text;
+}

--- a/packages/capnp-ts-test/test/integration/annotated.spec.ts
+++ b/packages/capnp-ts-test/test/integration/annotated.spec.ts
@@ -1,0 +1,46 @@
+import tap from "tap";
+import * as capnp from "capnp-ts";
+import { _capnpFileAnnotations, Crate, Widget } from "./annotated.capnp.js";
+
+const TAG = "ea88d419cd1a22c8";
+const WEIGHT = "b5f27ed23bfae214";
+
+void tap.test("runtime annotation metadata", (t) => {
+  t.strictSame(_capnpFileAnnotations, [{ id: TAG, value: "file-note" }]);
+
+  t.strictSame(Widget._capnp.annotations, [{ id: TAG, value: "widget" }]);
+
+  t.strictSame(Widget._capnp.fieldAnnotations, {
+    name: [
+      { id: TAG, value: "name" },
+      { id: WEIGHT, value: 42 },
+    ],
+  });
+
+  t.end();
+});
+
+void tap.test("annotation lookup helpers", (t) => {
+  t.equal(capnp.getAnnotation(Widget, TAG), "widget");
+  t.equal(capnp.getAnnotation(Widget, WEIGHT), undefined);
+  t.strictSame(capnp.getAnnotations(Widget, TAG), ["widget"]);
+
+  // Duplicate applications are preserved in order; getAnnotation returns the last.
+  t.strictSame(capnp.getAnnotations(Crate, TAG), ["first", "second"]);
+  t.equal(capnp.getAnnotation(Crate, TAG), "second");
+
+  t.end();
+});
+
+void tap.test("annotations are typed on the generic ctor interfaces", (t) => {
+  // The annotations here are the test: this must compile with StructCtor's declared types, no casts.
+
+  const generic: capnp.StructCtor<Widget> = Widget;
+  const annotations: capnp.SchemaAnnotation[] | undefined = generic._capnp.annotations;
+  const fieldAnnotations: { [field: string]: capnp.SchemaAnnotation[] } | undefined = generic._capnp.fieldAnnotations;
+
+  t.strictSame(annotations, [{ id: TAG, value: "widget" }]);
+  t.equal(fieldAnnotations?.name.length, 2);
+
+  t.end();
+});

--- a/packages/capnp-ts/src/annotations.ts
+++ b/packages/capnp-ts/src/annotations.ts
@@ -1,0 +1,48 @@
+/**
+ * Runtime schema annotation metadata, as emitted into generated code (`_capnp.annotations`,
+ * `_capnp.fieldAnnotations`, and `_capnpFileAnnotations`).
+ *
+ * @author jdiaz5513
+ */
+
+/** A single annotation application. The id is the annotation node's id as a hex string, like `_capnp.id`. */
+
+export interface SchemaAnnotation {
+  id: string;
+  value: unknown;
+}
+
+/** Anything generated that can carry schema annotations (a struct or interface class). */
+
+interface Annotated {
+  _capnp: { annotations?: SchemaAnnotation[] };
+}
+
+/**
+ * Look up the value of an annotation by id. The same annotation may legally be applied more than once; this returns
+ * the last application. Use {@link getAnnotations} to see all of them.
+ *
+ * @export
+ * @param {Annotated} target The generated class to inspect.
+ * @param {string} id The annotation node's id as a hex string.
+ * @returns {unknown} The last applied value, or `undefined` if the annotation is not applied.
+ */
+
+export function getAnnotation(target: Annotated, id: string): unknown {
+  const values = getAnnotations(target, id);
+
+  return values.length > 0 ? values[values.length - 1] : undefined;
+}
+
+/**
+ * Look up all applied values of an annotation by id, in declaration order.
+ *
+ * @export
+ * @param {Annotated} target The generated class to inspect.
+ * @param {string} id The annotation node's id as a hex string.
+ * @returns {unknown[]} The applied values; empty if the annotation is not applied.
+ */
+
+export function getAnnotations(target: Annotated, id: string): unknown[] {
+  return (target._capnp.annotations ?? []).filter((a) => a.id === id).map((a) => a.value);
+}

--- a/packages/capnp-ts/src/index.ts
+++ b/packages/capnp-ts/src/index.ts
@@ -51,6 +51,8 @@ export {
   getUint8Mask,
 } from "./serialization";
 
+export { getAnnotation, getAnnotations, SchemaAnnotation } from "./annotations";
+
 export { base64ToBytes, bytesToBase64 } from "./util";
 
 export {

--- a/packages/capnp-ts/src/rpc/conn.ts
+++ b/packages/capnp-ts/src/rpc/conn.ts
@@ -25,6 +25,7 @@ import {
   Payload,
   Return_Which,
 } from "../std/rpc.capnp.js";
+import { SchemaAnnotation } from "../annotations";
 import { RPC_NO_MAIN_INTERFACE, RPC_UNKNOWN_ANSWER_ID, RPC_UNKNOWN_EXPORT_ID } from "../errors";
 import { format } from "../util";
 import { Message } from "../serialization/message";
@@ -121,7 +122,7 @@ export interface ConnOptions {
 /** The static surface of a generated interface class, as far as Conn is concerned. */
 
 export interface InterfaceCtor<C> {
-  readonly _capnp: { displayName: string; id: string };
+  readonly _capnp: { annotations?: SchemaAnnotation[]; displayName: string; id: string };
   readonly Client: new (client: Client) => C;
 }
 

--- a/packages/capnp-ts/src/serialization/pointers/struct.ts
+++ b/packages/capnp-ts/src/serialization/pointers/struct.ts
@@ -4,6 +4,7 @@
 
 import initTrace from "debug";
 
+import { SchemaAnnotation } from "../../annotations";
 import { MAX_DEPTH, NATIVE_LITTLE_ENDIAN } from "../../constants";
 import { format, padToWord } from "../../util";
 import { ListElementSize } from "../list-element-size";
@@ -52,6 +53,8 @@ trace("load");
 const TMP_WORD = new DataView(new ArrayBuffer(8));
 
 export interface _StructCtor extends _PointerCtor {
+  readonly annotations?: SchemaAnnotation[];
+  readonly fieldAnnotations?: { [field: string]: SchemaAnnotation[] };
   readonly id: string;
   readonly size: ObjectSize;
 }

--- a/packages/capnpc-ts/src/generators.ts
+++ b/packages/capnpc-ts/src/generators.ts
@@ -29,6 +29,14 @@ import { createValueExpression } from "./values";
 const trace = initTrace("capnpc:generators");
 trace("load");
 
+/** `[{ id: "ea88d419cd1a22c8", value: "widget" }]` — annotation ids are hex strings like `_capnp.id`. */
+
+export function annotationsExpression(annotations: s.Annotation[]): string {
+  return `[${annotations
+    .map((a) => `{ id: ${str(a.getId().toString(16))}, value: ${createValueExpression(a.getValue())} }`)
+    .join(", ")}]`;
+}
+
 export function generateCapnpImport(ctx: CodeGeneratorFileContext): void {
   const fileNode = lookupNode(ctx, ctx.file);
   const tsFileId = util.hexToBigInt(TS_FILE_ID);
@@ -160,6 +168,12 @@ export function generateFileId(ctx: CodeGeneratorFileContext): void {
   trace("generateFileId()");
 
   ctx.sourceParts.push(`export const _capnpFileId = BigInt(${str(`0x${ctx.file.getId().toString(16)}`)});`);
+
+  const fileAnnotations = lookupNode(ctx, ctx.file).getAnnotations().toArray();
+
+  if (fileAnnotations.length > 0) {
+    ctx.sourceParts.push(`export const _capnpFileAnnotations = ${annotationsExpression(fileAnnotations)};`);
+  }
 }
 
 export function generateInterfaceClasses(ctx: CodeGeneratorFileContext, node: s.Node): void {
@@ -994,7 +1008,24 @@ export function generateStructNode(ctx: CodeGeneratorFileContext, node: s.Node, 
     `displayName: ${str(displayNamePrefix)}`,
     `id: ${str(nodeIdHex)}`,
     `size: new __O(${dataByteLength}, ${pointerCount})`,
-  ].concat(defaultValues);
+  ];
+
+  // Schema annotations surface at runtime so applications can build their own behavior on them (#126).
+  const nodeAnnotations = node.getAnnotations().toArray();
+
+  if (nodeAnnotations.length > 0) capnpProps.push(`annotations: ${annotationsExpression(nodeAnnotations)}`);
+
+  const annotatedFields = fields.filter((f) => f.getAnnotations().getLength() > 0);
+
+  if (annotatedFields.length > 0) {
+    capnpProps.push(
+      `fieldAnnotations: { ${annotatedFields
+        .map((f) => `${str(f.getName())}: ${annotationsExpression(f.getAnnotations().toArray())}`)
+        .join(", ")} }`,
+    );
+  }
+
+  capnpProps.push(...defaultValues);
   members.push(`static readonly _capnp = { ${capnpProps.join(", ")} };`);
 
   // static _ConcreteListClass: MyStruct_ConcreteListClass;


### PR DESCRIPTION
This allows using `capnp.getAnnotation()`/`capnp.getAnnotations()` to look up schema-level annotations for any struct. File level annotations are exported as `_capnpFileAnnotations`.

Closes #126.